### PR TITLE
Fix create_app arguments in data population scripts

### DIFF
--- a/namwoo_app/initial_data_scripts/populate_batteries.py
+++ b/namwoo_app/initial_data_scripts/populate_batteries.py
@@ -52,7 +52,10 @@ def populate_batteries_from_json():
         logger.error(f"ABORTING: Data file not found: {JSON_DATA_FILE}")
         return
 
-    flask_app = create_app(os.getenv('FLASK_CONFIG') or 'default')
+    # create_app() defaults to using the Config class from config/config.py.
+    # Passing a string like 'default' leads to ImportStringError, so we simply
+    # call it without arguments.
+    flask_app = create_app()
 
     with flask_app.app_context():
         with get_db_session() as session: 

--- a/namwoo_app/initial_data_scripts/populate_battery_to_vehicle_links.py
+++ b/namwoo_app/initial_data_scripts/populate_battery_to_vehicle_links.py
@@ -54,7 +54,9 @@ def populate_battery_vehicle_links(): # Renamed function for clarity
         logger.error(f"ABORTING: Data file not found: {JSON_DATA_FILE}")
         return
 
-    flask_app = create_app(os.getenv('FLASK_CONFIG') or 'default')
+    # create_app() uses the default Config; passing a string can cause
+    # ImportStringError, so do not provide one.
+    flask_app = create_app()
     with flask_app.app_context():
         with get_db_session() as session:
             if not session:

--- a/namwoo_app/initial_data_scripts/populate_vehicle_configurations.py
+++ b/namwoo_app/initial_data_scripts/populate_vehicle_configurations.py
@@ -50,7 +50,10 @@ def populate_vehicle_configurations():
         logger.error(f"ABORTING: Data file not found: {JSON_DATA_FILE}")
         return
 
-    flask_app = create_app(os.getenv('FLASK_CONFIG') or 'default') # Create app instance
+    # Use create_app() without arguments so it loads the default Config
+    # class defined in config/config.py. Passing a string like 'default'
+    # will trigger an ImportStringError in Flask.
+    flask_app = create_app()  # Create app instance
     with flask_app.app_context(): # Establish application context
         with get_db_session() as session: # Use your context-managed session
             if not session:


### PR DESCRIPTION
## Summary
- avoid passing string into `create_app`
- call `create_app()` directly in initial data scripts

## Testing
- `python -m py_compile namwoo_app/initial_data_scripts/populate_batteries.py`
- `python -m py_compile namwoo_app/initial_data_scripts/populate_battery_to_vehicle_links.py`
- `python -m py_compile namwoo_app/initial_data_scripts/populate_vehicle_configurations.py`


------
https://chatgpt.com/codex/tasks/task_e_6843d9cd91cc832b8b3e0f615e0ede0a