### PR TITLE
Add email processor implementation

### DIFF
--- a/namwoo_app/.env.example
+++ b/namwoo_app/.env.example
@@ -87,3 +87,18 @@ PRODUCT_SEARCH_LIMIT=10
 # If using PROMPT_FILE_PATH, you can leave this empty or as default.
 # Otherwise, paste a short inline prompt here.
 SYSTEM_PROMPT="Default assistant prompt. Load full prompt from PROMPT_FILE_PATH if needed."
+
+# --- Email Processor Configuration ---
+# IMAP credentials for the mailbox where price update CSVs arrive
+IMAP_SERVER="imap.your-email-provider.com"
+EMAIL_USER_IMAP="price-updates@example.com"
+EMAIL_PASS_IMAP="your_strong_mail_password"
+
+# API endpoint and credentials for sending parsed price updates
+NAMFULGOR_API_PRICE_UPDATE_URL="http://namfulgor_app:5000/api/battery/update-prices"
+INTERNAL_SERVICE_API_KEY="your_internal_service_api_key"
+
+# Optional behaviour controls for the email processor
+EMAIL_POLLING_INTERVAL_SECONDS=600
+EXPECTED_EMAIL_SUBJECT="Battery Price Update"
+AUTHORIZED_EMAIL_SENDER="authorized_sender@example.com"

--- a/namwoo_app/email_processor/processor.py
+++ b/namwoo_app/email_processor/processor.py
@@ -1,0 +1,76 @@
+import csv
+import io
+import os
+import time
+from typing import List, Dict
+
+import requests
+from dotenv import load_dotenv
+from imap_tools import MailBox, AND, MailMessageFlags
+
+
+load_dotenv()
+
+IMAP_SERVER = os.environ.get('IMAP_SERVER')
+EMAIL_USER_IMAP = os.environ.get('EMAIL_USER_IMAP')
+EMAIL_PASS_IMAP = os.environ.get('EMAIL_PASS_IMAP')
+API_URL = os.environ.get('NAMFULGOR_API_PRICE_UPDATE_URL')
+API_KEY = os.environ.get('NAMFULGOR_INTERNAL_API_KEY') or os.environ.get('INTERNAL_SERVICE_API_KEY')
+POLL_INTERVAL = int(os.environ.get('EMAIL_POLLING_INTERVAL_SECONDS', '600'))
+EXPECTED_EMAIL_SUBJECT = os.environ.get('EXPECTED_EMAIL_SUBJECT')
+AUTHORIZED_EMAIL_SENDER = os.environ.get('AUTHORIZED_EMAIL_SENDER')
+
+
+def parse_csv_payload(payload: bytes) -> List[Dict[str, str]]:
+    text = payload.decode()
+    reader = csv.DictReader(io.StringIO(text))
+    return [row for row in reader]
+
+
+def send_price_updates(rows: List[Dict[str, str]]) -> None:
+    if not API_URL or not API_KEY:
+        print("API_URL or API_KEY missing. Skipping update.")
+        return
+    try:
+        resp = requests.post(
+            API_URL,
+            json=rows,
+            headers={"X-API-KEY": API_KEY},
+            timeout=15,
+        )
+        print(f"Sent {len(rows)} updates. Status: {resp.status_code}")
+    except requests.RequestException as exc:
+        print(f"Error sending updates: {exc}")
+
+
+def process_mailbox(mailbox: MailBox) -> None:
+    criteria = AND(seen=False)
+    if EXPECTED_EMAIL_SUBJECT:
+        criteria &= AND(subject=EXPECTED_EMAIL_SUBJECT)
+    if AUTHORIZED_EMAIL_SENDER:
+        criteria &= AND(from_=AUTHORIZED_EMAIL_SENDER)
+
+    for msg in mailbox.fetch(criteria):
+        updates: List[Dict[str, str]] = []
+        for att in msg.attachments:
+            if att.filename and att.filename.lower().endswith('.csv'):
+                updates.extend(parse_csv_payload(att.payload))
+        if updates:
+            send_price_updates(updates)
+        mailbox.flag(msg.uid, MailMessageFlags.SEEN, True)
+
+
+def main() -> None:
+    if not IMAP_SERVER or not EMAIL_USER_IMAP or not EMAIL_PASS_IMAP:
+        raise RuntimeError("IMAP credentials are not fully configured")
+    while True:
+        try:
+            with MailBox(IMAP_SERVER).login(EMAIL_USER_IMAP, EMAIL_PASS_IMAP) as mbox:
+                process_mailbox(mbox)
+        except Exception as exc:
+            print(f"Error processing mailbox: {exc}")
+        time.sleep(POLL_INTERVAL)
+
+
+if __name__ == '__main__':
+    main()

--- a/namwoo_app/email_processor/requirements.txt
+++ b/namwoo_app/email_processor/requirements.txt
@@ -1,3 +1,3 @@
 requests
 python-dotenv
-# imap-tools (optional)
+imap-tools


### PR DESCRIPTION
## Summary
- implement simple IMAP polling script to parse CSV attachments and call battery price update API
- document email processor variables in `.env.example`
- add `imap-tools` to email processor requirements

## Testing
- `python -m py_compile namwoo_app/email_processor/processor.py`

------
https://chatgpt.com/codex/tasks/task_e_6843deb3d0f8832ba5b67a5d6737a88d