### PR TITLE
Fix column name mismatch

### DIFF
--- a/namwoo_app/initial_data_scripts/populate_batteries.py
+++ b/namwoo_app/initial_data_scripts/populate_batteries.py
@@ -96,7 +96,7 @@ def populate_batteries_from_json():
                     "model_code": model_code, 
                     # No 'original_input_model_code' in your Product model, so it's not passed
                     "price_regular": str(bat_json_data.get("price_full")), 
-                    "battery_price_discount_fx": str(bat_json_data.get("price_discounted_usd")), 
+                    "price_discount_fx": str(bat_json_data.get("price_discounted_usd")),
                     "warranty_months": bat_json_data.get("warranty_months"),
                     # These fields are in your Product model, ensure they are in your JSON or handle defaults
                     "item_name": bat_json_data.get("item_name", f"{brand} {model_code}"), 

--- a/namwoo_app/models/product.py
+++ b/namwoo_app/models/product.py
@@ -55,7 +55,7 @@ class Product(Base):
     description = Column(Text, nullable=True, comment="Additional details or features of the battery (plain text expected)")
     warranty_months = Column(Integer, nullable=True, comment="Warranty in months for the battery")
     price_regular = Column(NUMERIC(12, 2), nullable=False, comment="Regular retail price")
-    battery_price_discount_fx = Column(NUMERIC(12, 2), nullable=True, comment="Special discounted price for FX payment") 
+    price_discount_fx = Column(NUMERIC(12, 2), nullable=True, comment="Special discounted price for FX payment")
     stock = Column(Integer, default=0, nullable=False, comment="Overall stock for this battery model")
     additional_data = Column(JSONB, nullable=True, comment="Stores pre-formatted message templates or other battery-specific JSON data")
     created_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), nullable=False)
@@ -81,7 +81,7 @@ class Product(Base):
             "description": self.description,
             "warranty_months": self.warranty_months,
             "price_regular": float(self.price_regular) if self.price_regular is not None else None,
-            "battery_price_discount_fx": float(self.battery_price_discount_fx) if self.battery_price_discount_fx is not None else None,
+            "price_discount_fx": float(self.price_discount_fx) if self.price_discount_fx is not None else None,
             "stock": self.stock,
             "additional_data": self.additional_data,
             "created_at": self.created_at.isoformat() if self.created_at else None,
@@ -99,12 +99,12 @@ class Product(Base):
                 message = message.replace("{MODEL_CODE}", self.model_code or "N/A")
                 message = message.replace("{WARRANTY_MONTHS}", str(self.warranty_months or "N/A"))
                 message = message.replace("{PRICE_REGULAR}", f"${float(self.price_regular):.2f}" if self.price_regular is not None else "N/A")
-                message = message.replace("{PRICE_DISCOUNT_FX}", f"${float(self.battery_price_discount_fx):.2f}" if self.battery_price_discount_fx is not None else "N/A")
+                message = message.replace("{PRICE_DISCOUNT_FX}", f"${float(self.price_discount_fx):.2f}" if self.price_discount_fx is not None else "N/A")
                 message = message.replace("{STOCK}", str(self.stock if self.stock is not None else "N/A"))
                 return message
 
         price_reg_str = f"Precio Regular: ${float(self.price_regular):.2f}" if self.price_regular is not None else "Precio Regular no disponible"
-        price_fx_str = f"Descuento Pago en Divisas: ${float(self.battery_price_discount_fx):.2f}" if self.battery_price_discount_fx is not None else ""
+        price_fx_str = f"Descuento Pago en Divisas: ${float(self.price_discount_fx):.2f}" if self.price_discount_fx is not None else ""
         warranty_str = f"Garantía: {self.warranty_months} meses" if self.warranty_months is not None else "Garantía no especificada"
         stock_str = f"Stock: {self.stock}" if self.stock is not None else "Stock no disponible"
         name_str = self.item_name or f"{self.brand} {self.model_code}"

--- a/namwoo_app/services/product_service.py
+++ b/namwoo_app/services/product_service.py
@@ -112,7 +112,7 @@ def add_or_update_battery_product(
                 if hasattr(entry, key):
                     current_value = getattr(entry, key)
                     # Handle price conversion to Decimal for comparison and setting
-                    if key in ["price_regular", "battery_price_discount_fx"] and new_value is not None:
+                    if key in ["price_regular", "price_discount_fx"] and new_value is not None:
                         try:
                             new_decimal_value = Decimal(str(new_value)).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
                             if current_value != new_decimal_value:
@@ -144,8 +144,8 @@ def add_or_update_battery_product(
             # Convert prices to Decimal before creating new object
             if "price_regular" in init_data and init_data["price_regular"] is not None:
                 init_data["price_regular"] = Decimal(str(init_data["price_regular"])).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
-            if "battery_price_discount_fx" in init_data and init_data["battery_price_discount_fx"] is not None:
-                init_data["battery_price_discount_fx"] = Decimal(str(init_data["battery_price_discount_fx"])).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
+            if "price_discount_fx" in init_data and init_data["price_discount_fx"] is not None:
+                init_data["price_discount_fx"] = Decimal(str(init_data["price_discount_fx"])).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
 
             entry = Product(**init_data)
             session.add(entry)
@@ -192,10 +192,11 @@ def update_battery_product_prices(
 
 
     if new_price_discount_fx is not None:
-        if not isinstance(new_price_discount_fx, Decimal): new_price_discount_fx = Decimal(str(new_price_discount_fx))
+        if not isinstance(new_price_discount_fx, Decimal):
+            new_price_discount_fx = Decimal(str(new_price_discount_fx))
         price_fx_quantized = new_price_discount_fx.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
-        if battery_product.battery_price_discount_fx != price_fx_quantized:
-            battery_product.battery_price_discount_fx = price_fx_quantized
+        if battery_product.price_discount_fx != price_fx_quantized:
+            battery_product.price_discount_fx = price_fx_quantized
             updated = True
             logger.info(f"Price discount fx for {battery_product_id} set to {price_fx_quantized}")
             


### PR DESCRIPTION
## Summary
- rename `battery_price_discount_fx` to `price_discount_fx` in Product model
- adjust product service and population script to use new field name

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6843e52d104c832b873194f401b11e36