### PR TITLE
Implement price update CSV parsing

### DIFF
--- a/namwoo_app/email_processor/processor.py
+++ b/namwoo_app/email_processor/processor.py
@@ -15,32 +15,45 @@ IMAP_SERVER = os.environ.get('IMAP_SERVER')
 EMAIL_USER_IMAP = os.environ.get('EMAIL_USER_IMAP')
 EMAIL_PASS_IMAP = os.environ.get('EMAIL_PASS_IMAP')
 API_URL = os.environ.get('NAMFULGOR_API_PRICE_UPDATE_URL')
-API_KEY = os.environ.get('NAMFULGOR_INTERNAL_API_KEY') or os.environ.get('INTERNAL_SERVICE_API_KEY')
+# API_KEY should primarily use INTERNAL_SERVICE_API_KEY but fall back to
+# NAMFULGOR_INTERNAL_API_KEY for backward compatibility
+API_KEY = os.environ.get('INTERNAL_SERVICE_API_KEY') or os.environ.get('NAMFULGOR_INTERNAL_API_KEY')
 POLL_INTERVAL = int(os.environ.get('EMAIL_POLLING_INTERVAL_SECONDS', '600'))
 EXPECTED_EMAIL_SUBJECT = os.environ.get('EXPECTED_EMAIL_SUBJECT')
 AUTHORIZED_EMAIL_SENDER = os.environ.get('AUTHORIZED_EMAIL_SENDER')
 
 
-def parse_csv_payload(payload: bytes) -> List[Dict[str, str]]:
-    """Parse CSV payload and return a list of standardized update dicts."""
-    text = payload.decode()
+def parse_csv_attachment_payload(payload: bytes) -> List[Dict[str, float]]:
+    """Parse CSV payload from an email attachment.
+
+    Expects headers named ``model_code`` and ``price_full`` exactly. All other
+    columns are ignored. Returns a list of dictionaries each containing
+    ``model_code`` and ``new_price`` (mapped from ``price_full``).
+    """
+    text = payload.decode(errors="ignore")
     reader = csv.DictReader(io.StringIO(text))
-    updates: List[Dict[str, str]] = []
+
+    updates: List[Dict[str, float]] = []
     for row in reader:
-        model_code = row.get('model_code') or row.get('MODEL_CODE')
-        new_price_val = row.get('new_price') or row.get('NEW_PRICE')
-        if not model_code or new_price_val is None:
+        model_code = row.get('model_code')
+        price_val = row.get('price_full')
+
+        if not model_code or price_val is None:
             continue
-        cleaned = ''.join(ch for ch in str(new_price_val) if ch.isdigit() or ch == '.')
+
+        cleaned = ''.join(ch for ch in str(price_val).replace(',', '') if ch.isdigit() or ch == '.')
         try:
             price_float = float(cleaned)
         except ValueError:
+            # Skip rows with invalid price values
             continue
+
         updates.append({'model_code': model_code.strip(), 'new_price': price_float})
+
     return updates
 
 
-def send_price_updates(rows: List[Dict[str, str]]) -> None:
+def send_price_updates(rows: List[Dict[str, float]]) -> None:
     if not API_URL or not API_KEY:
         print("API_URL or API_KEY missing. Skipping update.")
         return
@@ -64,10 +77,10 @@ def process_mailbox(mailbox: MailBox) -> None:
         criteria &= AND(from_=AUTHORIZED_EMAIL_SENDER)
 
     for msg in mailbox.fetch(criteria):
-        updates: List[Dict[str, str]] = []
+        updates: List[Dict[str, float]] = []
         for att in msg.attachments:
             if att.filename and att.filename.lower().endswith('.csv'):
-                updates.extend(parse_csv_payload(att.payload))
+                updates.extend(parse_csv_attachment_payload(att.payload))
         if updates:
             send_price_updates(updates)
         mailbox.flag(msg.uid, MailMessageFlags.SEEN, True)


### PR DESCRIPTION
## Summary
- update email processor to parse `price_full` column from CSV
- expect `model_code` and `price_full` headers
- send data to API using `X-Internal-API-Key`

## Testing
- `python -m py_compile namwoo_app/email_processor/processor.py`
- `python -m py_compile namwoo_app/api/battery_api_routes.py`
- `python -m py_compile namwoo_app/services/product_service.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684513f1c300832bbeeeec43db7b64df