### PR TITLE
Fix email processor search criteria

### DIFF
--- a/namwoo_app/email_processor/processor.py
+++ b/namwoo_app/email_processor/processor.py
@@ -123,11 +123,12 @@ def send_price_updates(rows: List[Dict[str, Any]]) -> None:
 
 def process_mailbox(mailbox: MailBox) -> None:
     logger.info("Processing mailbox for new emails...")
-    criteria = AND(seen=False)
+    search_kwargs = {"seen": False}
     if EXPECTED_EMAIL_SUBJECT:
-        criteria &= AND(subject=EXPECTED_EMAIL_SUBJECT)
+        search_kwargs["subject"] = EXPECTED_EMAIL_SUBJECT
     if AUTHORIZED_EMAIL_SENDER:
-        criteria &= AND(from_=AUTHORIZED_EMAIL_SENDER)
+        search_kwargs["from_"] = AUTHORIZED_EMAIL_SENDER
+    criteria = AND(**search_kwargs)
     logger.debug(f"IMAP search criteria: {criteria}")
 
     found = False


### PR DESCRIPTION
## Summary
- avoid bitwise operations on imap_tools AND objects
- construct search kwargs dynamically instead

## Testing
- `python3 -m py_compile namwoo_app/email_processor/processor.py`


------
https://chatgpt.com/codex/tasks/task_e_6845284fac74832b860cf0d823c768e2