### PR TITLE
Fix UTF-8 search for email processor

### DIFF
--- a/namwoo_app/email_processor/processor.py
+++ b/namwoo_app/email_processor/processor.py
@@ -132,7 +132,9 @@ def process_mailbox(mailbox: MailBox) -> None:
     logger.debug(f"IMAP search criteria: {criteria}")
 
     found = False
-    for msg in mailbox.fetch(criteria):
+    # Explicitly specify UTF-8 charset for search criteria to handle
+    # non-ASCII subjects or sender names (e.g. accented characters).
+    for msg in mailbox.fetch(criteria, charset="utf-8"):
         found = True
         logger.info(
             f"Processing email UID: {msg.uid}, From: {msg.from_}, Subject: {msg.subject}"


### PR DESCRIPTION
## Summary
- handle non-ASCII subjects while searching IMAP mailbox

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_684531ecec18832bb3123e368b7fa4a8